### PR TITLE
fixed loan js library to avoid off-by-one error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@danacita/loanjs",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -189,6 +189,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -370,7 +371,8 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.2",
@@ -484,6 +486,7 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -1686,7 +1689,8 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "email": "dennisjuanito@gmail.com"
   },
   "contributors": [
-    "Veri Ferdiansyah <veri@danacita.com>"
+    "Veri Ferdiansyah <veri@danacita.com>",
+    "Kai Yuan Neo <kai@danacita.com"
   ],
   "dependencies": {
     "@types/lodash": "^4.14.121",

--- a/src/repaymentSchedule.ts
+++ b/src/repaymentSchedule.ts
@@ -104,11 +104,15 @@ export default class RepaymentSchedule {
       (value: any): RepaymentScheduleJSON => {
         return {
           date: moment(value.date).format('D-MMM-YYYY'),
-          month: Math.round(value.month),
-          balance: Math.abs(Math.round(value.balance)),
-          payment: Math.round(value.payment),
-          interest: Math.round(value.interest),
-          principal: Math.round(value.principal)
+          month: value.month,
+          // Use ceiling on balance to avoid negative balance
+          // Use absolute value on balance to avoid -0
+          balance: Math.abs(Math.ceil(value.balance)),
+          // Use ceiling as scheduled payment to avoid off-by-one errors, such that
+          // borrower can always pay an integer amount and it will always be sufficient.
+          payment: Math.ceil(value.payment),
+          interest: value.interest,
+          principal: value.principal
         };
       }
     );

--- a/src/test/fixtures/index.ts
+++ b/src/test/fixtures/index.ts
@@ -1,419 +1,391 @@
 export const expectedRepaymentScheduleOne = [
-  {
-    date: '14-Jul-2019',
-    month: 0,
-    balance: 2694720,
-    payment: 0,
-    interest: 0,
-    principal: 0
-  },
+  { date: '14-Jul-2019', month: 0, balance: 2694720, payment: 0, interest: 0, principal: 0 },
   {
     date: '14-Aug-2019',
     month: 1,
-    balance: 2577712,
-    payment: 215814,
-    interest: 98806,
-    principal: 117008
+    balance: 2577713,
+    payment: 215815,
+    interest: 98806.4,
+    principal: 117007.7527690432
   },
   {
     date: '14-Sep-2019',
     month: 2,
-    balance: 2456414,
-    payment: 215814,
-    interest: 94516,
-    principal: 121298
+    balance: 2456415,
+    payment: 215815,
+    interest: 94516.11573180175,
+    principal: 121298.03703724145
   },
   {
     date: '14-Oct-2019',
     month: 3,
     balance: 2330669,
-    payment: 215814,
-    interest: 90069,
-    principal: 125746
+    payment: 215815,
+    interest: 90068.52104043623,
+    principal: 125745.63172860697
   },
   {
     date: '14-Nov-2019',
     month: 4,
-    balance: 2200312,
-    payment: 215814,
-    interest: 85458,
-    principal: 130356
+    balance: 2200313,
+    payment: 215815,
+    interest: 85457.847877054,
+    principal: 130356.3048919892
   },
   {
     date: '14-Dec-2019',
     month: 5,
-    balance: 2065176,
-    payment: 215814,
-    interest: 80678,
-    principal: 135136
+    balance: 2065177,
+    payment: 215815,
+    interest: 80678.11669768105,
+    principal: 135136.03607136215
   },
   {
     date: '14-Jan-2020',
     month: 6,
-    balance: 1925085,
-    payment: 215814,
-    interest: 75723,
-    principal: 140091
+    balance: 1925086,
+    payment: 215815,
+    interest: 75723.12870839778,
+    principal: 140091.02406064543
   },
   {
     date: '14-Feb-2020',
     month: 7,
     balance: 1779858,
-    payment: 215814,
-    interest: 70586,
-    principal: 145228
+    payment: 215815,
+    interest: 70586.45782617411,
+    principal: 145227.69494286907
   },
   {
     date: '14-Mar-2020',
     month: 8,
     balance: 1629305,
-    payment: 215814,
-    interest: 65261,
-    principal: 150553
+    payment: 215815,
+    interest: 65261.44234493558,
+    principal: 150552.71042410762
   },
   {
     date: '14-Apr-2020',
     month: 9,
     balance: 1473232,
-    payment: 215814,
-    interest: 59741,
-    principal: 156073
+    payment: 215815,
+    interest: 59741.17629605163,
+    principal: 156072.97647299158
   },
   {
     date: '14-May-2020',
     month: 10,
-    balance: 1311436,
-    payment: 215814,
-    interest: 54019,
-    principal: 161796
+    balance: 1311437,
+    payment: 215815,
+    interest: 54018.50049204194,
+    principal: 161795.65227700127
   },
   {
     date: '14-Jun-2020',
     month: 11,
-    balance: 1143708,
-    payment: 215814,
-    interest: 48086,
-    principal: 167728
+    balance: 1143709,
+    payment: 215815,
+    interest: 48085.99324188523,
+    principal: 167728.15952715796
   },
   {
     date: '14-Jul-2020',
     month: 12,
     balance: 969830,
-    payment: 215814,
-    interest: 41936,
-    principal: 173878
+    payment: 215815,
+    interest: 41935.96072588944,
+    principal: 173878.19204315374
   },
   {
     date: '14-Aug-2020',
     month: 13,
-    balance: 789576,
-    payment: 215814,
-    interest: 35560,
-    principal: 180254
+    balance: 789577,
+    payment: 215815,
+    interest: 35560.42701764047,
+    principal: 180253.72575140273
   },
   {
     date: '14-Sep-2020',
     month: 14,
-    balance: 602713,
-    payment: 215814,
-    interest: 28951,
-    principal: 186863
+    balance: 602714,
+    payment: 215815,
+    interest: 28951.12374008903,
+    principal: 186863.02902895416
   },
   {
     date: '14-Oct-2020',
     month: 15,
-    balance: 408998,
-    payment: 215814,
-    interest: 22099,
-    principal: 193715
+    balance: 408999,
+    payment: 215815,
+    interest: 22099.47934236071,
+    principal: 193714.67342668248
   },
   {
     date: '14-Nov-2020',
     month: 16,
     balance: 208181,
-    payment: 215814,
-    interest: 14997,
-    principal: 200818
+    payment: 215815,
+    interest: 14996.607983382353,
+    principal: 200817.54478566084
   },
   {
     date: '14-Dec-2020',
     month: 17,
     balance: 0,
-    payment: 215814,
-    interest: 7633,
-    principal: 208181
+    payment: 215815,
+    interest: 7633.298007908123,
+    principal: 208180.85476113507
   }
 ];
 
 export const expectedRepaymentScheduleTwo = [
-  {
-    date: '7-May-2017',
-    month: 0,
-    balance: 1375000,
-    payment: 0,
-    interest: 0,
-    principal: 0
-  },
+  { date: '7-May-2017', month: 0, balance: 1375000, payment: 0, interest: 0, principal: 0 },
   {
     date: '7-Jun-2017',
     month: 1,
     balance: 1183428,
     payment: 203031,
-    interest: 11458,
-    principal: 191572
+    interest: 11458.333333333334,
+    principal: 191572.1914239711
   },
   {
     date: '7-Jul-2017',
     month: 2,
-    balance: 990259,
+    balance: 990260,
     payment: 203031,
-    interest: 9862,
-    principal: 193169
+    interest: 9861.89840480024,
+    principal: 193168.6263525042
   },
   {
     date: '7-Aug-2017',
     month: 3,
     balance: 795481,
     payment: 203031,
-    interest: 8252,
-    principal: 194778
+    interest: 8252.159851862705,
+    principal: 194778.36490544173
   },
   {
     date: '7-Sep-2017',
     month: 4,
-    balance: 599079,
+    balance: 599080,
     payment: 203031,
-    interest: 6629,
-    principal: 196402
+    interest: 6629.006810984024,
+    principal: 196401.5179463204
   },
   {
     date: '7-Oct-2017',
     month: 5,
-    balance: 401041,
+    balance: 401042,
     payment: 203031,
-    interest: 4992,
-    principal: 198038
+    interest: 4992.327494764687,
+    principal: 198038.19726253973
   },
   {
     date: '7-Nov-2017',
     month: 6,
     balance: 201353,
     payment: 203031,
-    interest: 3342,
-    principal: 199689
+    interest: 3342.009184243522,
+    principal: 199688.5155730609
   },
   {
     date: '7-Dec-2017',
     month: 7,
     balance: 0,
     payment: 203031,
-    interest: 1678,
-    principal: 201353
+    interest: 1677.9382211346815,
+    principal: 201352.58653616975
   }
 ];
 
 export const expectedRepaymentScheduleThree = [
-  {
-    date: '8-Dec-2022',
-    month: 0,
-    balance: 4656115,
-    payment: 0,
-    interest: 0,
-    principal: 0
-  },
+  { date: '8-Dec-2022', month: 0, balance: 4656115, payment: 0, interest: 0, principal: 0 },
   {
     date: '8-Jan-2023',
     month: 1,
     balance: 4480783,
-    payment: 256814,
-    interest: 81482,
-    principal: 175332
+    payment: 256815,
+    interest: 81482.01250000001,
+    principal: 175332.4273323332
   },
   {
     date: '8-Feb-2023',
     month: 2,
     balance: 4302382,
-    payment: 256814,
-    interest: 78414,
-    principal: 178401
+    payment: 256815,
+    interest: 78413.69502168418,
+    principal: 178400.74481064902
   },
   {
     date: '8-Mar-2023',
     month: 3,
-    balance: 4120859,
-    payment: 256814,
-    interest: 75292,
-    principal: 181523
+    balance: 4120860,
+    payment: 256815,
+    interest: 75291.68198749781,
+    principal: 181522.7578448354
   },
   {
     date: '8-Apr-2023',
     month: 4,
     balance: 3936160,
-    payment: 256814,
-    interest: 72115,
-    principal: 184699
+    payment: 256815,
+    interest: 72115.03372521319,
+    principal: 184699.40610712004
   },
   {
     date: '8-May-2023',
     month: 5,
-    balance: 3748228,
-    payment: 256814,
-    interest: 68883,
-    principal: 187932
+    balance: 3748229,
+    payment: 256815,
+    interest: 68882.79411833858,
+    principal: 187931.64571399463
   },
   {
     date: '8-Jun-2023',
     month: 6,
     balance: 3557008,
-    payment: 256814,
-    interest: 65594,
-    principal: 191220
+    payment: 256815,
+    interest: 65593.99031834368,
+    principal: 191220.44951398953
   },
   {
     date: '8-Jul-2023',
     month: 7,
     balance: 3362441,
-    payment: 256814,
-    interest: 62248,
-    principal: 194567
+    payment: 256815,
+    interest: 62247.63245184886,
+    principal: 194566.80738048436
   },
   {
     date: '8-Aug-2023',
     month: 8,
-    balance: 3164469,
-    payment: 256814,
-    interest: 58843,
-    principal: 197972
+    balance: 3164470,
+    payment: 256815,
+    interest: 58842.71332269038,
+    principal: 197971.72650964285
   },
   {
     date: '8-Sep-2023',
     month: 9,
     balance: 2963033,
-    payment: 256814,
-    interest: 55378,
-    principal: 201436
+    payment: 256815,
+    interest: 55378.208108771636,
+    principal: 201436.2317235616
   },
   {
     date: '8-Oct-2023',
     month: 10,
-    balance: 2758071,
-    payment: 256814,
-    interest: 51853,
-    principal: 204961
+    balance: 2758072,
+    payment: 256815,
+    interest: 51853.074053609314,
+    principal: 204961.3657787239
   },
   {
     date: '8-Nov-2023',
     month: 11,
-    balance: 2549523,
-    payment: 256814,
-    interest: 48266,
-    principal: 208548
+    balance: 2549524,
+    payment: 256815,
+    interest: 48266.25015248165,
+    principal: 208548.18967985158
   },
   {
     date: '8-Dec-2023',
     month: 12,
-    balance: 2337325,
-    payment: 256814,
-    interest: 44617,
-    principal: 212198
+    balance: 2337326,
+    payment: 256815,
+    interest: 44616.65683308424,
+    principal: 212197.78299924897
   },
   {
     date: '8-Jan-2024',
     month: 13,
-    balance: 2121414,
-    payment: 256814,
-    interest: 40903,
-    principal: 215911
+    balance: 2121415,
+    payment: 256815,
+    interest: 40903.19563059738,
+    principal: 215911.24420173583
   },
   {
     date: '8-Feb-2024',
     month: 14,
     balance: 1901725,
-    payment: 256814,
-    interest: 37125,
-    principal: 219690
+    payment: 256815,
+    interest: 37124.748857067,
+    principal: 219689.69097526622
   },
   {
     date: '8-Mar-2024',
     month: 15,
-    balance: 1678190,
-    payment: 256814,
-    interest: 33280,
-    principal: 223534
+    balance: 1678191,
+    payment: 256815,
+    interest: 33280.179264999846,
+    principal: 223534.26056733337
   },
   {
     date: '8-Apr-2024',
     month: 16,
-    balance: 1450744,
-    payment: 256814,
-    interest: 29368,
-    principal: 227446
+    balance: 1450745,
+    payment: 256815,
+    interest: 29368.329705071512,
+    principal: 227446.1101272617
   },
   {
     date: '8-May-2024',
     month: 17,
     balance: 1219318,
-    payment: 256814,
-    interest: 25388,
-    principal: 231426
+    payment: 256815,
+    interest: 25388.02277784443,
+    principal: 231426.4170544888
   },
   {
     date: '8-Jun-2024',
     month: 18,
-    balance: 983841,
-    payment: 256814,
-    interest: 21338,
-    principal: 235476
+    balance: 983842,
+    payment: 256815,
+    interest: 21338.06047939088,
+    principal: 235476.37935294234
   },
   {
     date: '8-Jul-2024',
     month: 19,
-    balance: 744244,
-    payment: 256814,
-    interest: 17217,
-    principal: 239597
+    balance: 744245,
+    payment: 256815,
+    interest: 17217.22384071439,
+    principal: 239597.2159916188
   },
   {
     date: '8-Aug-2024',
     month: 20,
     balance: 500454,
-    payment: 256814,
-    interest: 13024,
-    principal: 243790
+    payment: 256815,
+    interest: 13024.272560861058,
+    principal: 243790.16727147216
   },
   {
     date: '8-Sep-2024',
     month: 21,
-    balance: 252397,
-    payment: 256814,
-    interest: 8758,
-    principal: 248056
+    balance: 252398,
+    payment: 256815,
+    interest: 8757.944633610294,
+    principal: 248056.49519872293
   },
   {
     date: '8-Oct-2024',
     month: 22,
-    balance: 0,
-    payment: 256814,
-    interest: 4417,
-    principal: 252397
+    balance: 1,
+    payment: 256815,
+    interest: 4416.955967632643,
+    principal: 252397.48386470057
   }
 ];
 
 export const expectedRepaymentScheduleGracePeriod = [
-  {
-    date: '2-Feb-2019',
-    month: 0,
-    balance: 36050000,
-    payment: 0,
-    interest: 0,
-    principal: 0
-  },
+  { date: '2-Feb-2019', month: 0, balance: 36050000, payment: 0, interest: 0, principal: 0 },
   {
     date: '2-Mar-2019',
     month: 1,
     balance: 36050000,
     payment: 841167,
-    interest: 841167,
+    interest: 841166.6666666667,
     principal: 0
   },
   {
@@ -421,7 +393,7 @@ export const expectedRepaymentScheduleGracePeriod = [
     month: 2,
     balance: 36050000,
     payment: 841167,
-    interest: 841167,
+    interest: 841166.6666666667,
     principal: 0
   },
   {
@@ -429,7 +401,7 @@ export const expectedRepaymentScheduleGracePeriod = [
     month: 3,
     balance: 36050000,
     payment: 841167,
-    interest: 841167,
+    interest: 841166.6666666667,
     principal: 0
   },
   {
@@ -437,7 +409,7 @@ export const expectedRepaymentScheduleGracePeriod = [
     month: 4,
     balance: 36050000,
     payment: 841167,
-    interest: 841167,
+    interest: 841166.6666666667,
     principal: 0
   },
   {
@@ -445,7 +417,7 @@ export const expectedRepaymentScheduleGracePeriod = [
     month: 5,
     balance: 36050000,
     payment: 841167,
-    interest: 841167,
+    interest: 841166.6666666667,
     principal: 0
   },
   {
@@ -453,7 +425,7 @@ export const expectedRepaymentScheduleGracePeriod = [
     month: 6,
     balance: 36050000,
     payment: 841167,
-    interest: 841167,
+    interest: 841166.6666666667,
     principal: 0
   },
   {
@@ -461,95 +433,95 @@ export const expectedRepaymentScheduleGracePeriod = [
     month: 7,
     balance: 33412126,
     payment: 3479041,
-    interest: 841167,
-    principal: 2637874
+    interest: 841166.6666666667,
+    principal: 2637874.2227311283
   },
   {
     date: '2-Oct-2019',
     month: 8,
-    balance: 30712701,
+    balance: 30712702,
     payment: 3479041,
-    interest: 779616,
-    principal: 2699425
+    interest: 779616.2681362737,
+    principal: 2699424.6212615217
   },
   {
     date: '2-Nov-2019',
     month: 9,
     balance: 27950290,
     payment: 3479041,
-    interest: 716630,
-    principal: 2762411
+    interest: 716629.6936401716,
+    principal: 2762411.1957576238
   },
   {
     date: '2-Dec-2019',
     month: 10,
     balance: 25123423,
     payment: 3479041,
-    interest: 652173,
-    principal: 2826867
+    interest: 652173.432405827,
+    principal: 2826867.456991968
   },
   {
     date: '2-Jan-2020',
     month: 11,
     balance: 22230595,
     payment: 3479041,
-    interest: 586213,
-    principal: 2892828
+    interest: 586213.1917426811,
+    principal: 2892827.6976551143
   },
   {
     date: '2-Feb-2020',
     month: 12,
     balance: 19270268,
     payment: 3479041,
-    interest: 518714,
-    principal: 2960327
+    interest: 518713.87879739504,
+    principal: 2960327.0106004
   },
   {
     date: '2-Mar-2020',
     month: 13,
-    balance: 16240866,
+    balance: 16240867,
     payment: 3479041,
-    interest: 449640,
-    principal: 3029401
+    interest: 449639.5818833857,
+    principal: 3029401.3075144095
   },
   {
     date: '2-Apr-2020',
     month: 14,
-    balance: 13140779,
+    balance: 13140780,
     payment: 3479041,
-    interest: 378954,
-    principal: 3100087
+    interest: 378953.55137471616,
+    principal: 3100087.338023079
   },
   {
     date: '2-May-2020',
     month: 15,
-    balance: 9968356,
+    balance: 9968357,
     payment: 3479041,
-    interest: 306618,
-    principal: 3172423
+    interest: 306618.1801541776,
+    principal: 3172422.709243618
   },
   {
     date: '2-Jun-2020',
     month: 16,
     balance: 6721911,
     payment: 3479041,
-    interest: 232595,
-    principal: 3246446
+    interest: 232594.98360515985,
+    principal: 3246445.9057926354
   },
   {
     date: '2-Jul-2020',
     month: 17,
-    balance: 3399714,
+    balance: 3399715,
     payment: 3479041,
-    interest: 156845,
-    principal: 3322196
+    interest: 156844.57913666504,
+    principal: 3322196.3102611303
   },
   {
     date: '2-Aug-2020',
     month: 18,
-    balance: 0,
+    balance: 1,
     payment: 3479041,
-    interest: 79327,
-    principal: 3399714
+    interest: 79326.66523057199,
+    principal: 3399714.224167223
   }
 ];


### PR DESCRIPTION
previously by rounding interest, principal, and payment, we would sometimes get off-by-one errors where interest and principal did not add up to payment. this fix updates code to not round interest and principal, and always take the ceiling of payment such that the total amount is always rounded up, and slightly greater than interest and principal.